### PR TITLE
Implement finding transactions

### DIFF
--- a/lib/cardgate/gateway.rb
+++ b/lib/cardgate/gateway.rb
@@ -29,7 +29,7 @@ module Cardgate
     def self.connection
       raise Cardgate::Exception, 'Merchant and/or API key not set' if !self.merchant || !self.api_key
 
-      Faraday.new(url: self.request_url) do |faraday|
+      Faraday.new(url: self.request_url, ssl: { verify: !is_test_environment? } ) do |faraday|
         faraday.request  :json
         faraday.response :json
         faraday.response :logger

--- a/lib/cardgate/transactions.rb
+++ b/lib/cardgate/transactions.rb
@@ -2,15 +2,9 @@ module Cardgate
 
   class Transactions
 
-    attr_reader :id
-
-    def initialize(id)
-      @id = id
-    end
-
-    def find
+    def self.find(transaction_id)
       result = Cardgate::Gateway.connection.get do |req|
-        req.url '/rest/v1/transactions/'
+        req.url "/rest/v1/transactions/#{transaction_id}"
         req.headers['Accept'] = 'application/json'
       end
 

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -4,18 +4,20 @@ module CardgateTestCases
 
   class TransactionsTestCases < Test::Unit::TestCase
 
-    def stub_cardgate_connection(response)
+    def stub_cardgate_connection
       cardgate_connection do |stubs|
-        stubs.get('/rest/v1/transactions/') { [200, {}, response] }
+        stubs.get('/rest/v1/transactions/2307824') { [200, {}, CardgateFixtures::TRANSACTION_WITHOUT_CUSTOMER] }
+        stubs.get('/rest/v1/transactions/2307825') { [200, {}, CardgateFixtures::TRANSACTION_WITH_CUSTOMER] }
+        stubs.get('/rest/v1/transactions/2307826') { [200, {}, nil] }
       end
     end
 
     def test_transaction_without_customer
-      cardgate_connection = stub_cardgate_connection(CardgateFixtures::TRANSACTION_WITHOUT_CUSTOMER)
+      cardgate_connection = stub_cardgate_connection()
 
       Cardgate::Gateway.stubs(:connection).returns(cardgate_connection)
 
-      transaction = Cardgate::Transactions.new(2307824).find
+      transaction = Cardgate::Transactions.find(2307824)
 
       assert transaction.is_a? Cardgate::Transaction
 
@@ -31,11 +33,11 @@ module CardgateTestCases
     end
 
     def test_transaction_with_customer
-      cardgate_connection = stub_cardgate_connection(CardgateFixtures::TRANSACTION_WITH_CUSTOMER)
+      cardgate_connection = stub_cardgate_connection()
 
       Cardgate::Gateway.stubs(:connection).returns(cardgate_connection)
 
-      transaction = Cardgate::Transactions.new(2307824).find
+      transaction = Cardgate::Transactions.find(2307825)
 
       assert_equal 'Youri', transaction.first_name
       assert_equal 'van der Lans', transaction.last_name
@@ -50,12 +52,12 @@ module CardgateTestCases
     end
 
     def test_empty_transaction
-      cardgate_connection = stub_cardgate_connection(nil)
+      cardgate_connection = stub_cardgate_connection()
 
       Cardgate::Gateway.stubs(:connection).returns(cardgate_connection)
 
       assert_raises Cardgate::Exception do
-        transaction = Cardgate::Transactions.new(2307824).find
+        transaction = Cardgate::Transactions.find(2307826)
       end
     end
 


### PR DESCRIPTION
- Make the find() method a class method on Cardgate::Transactions
- Move the test fixtures to the stub method so we don't pass around
  extra arguments and we can really stub based on a real transaction id.
