### PR TITLE
loosen gemspec dependencies

### DIFF
--- a/cardgate.gemspec
+++ b/cardgate.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
 
-  spec.add_dependency "faraday", "~> 0.8.9"
-  spec.add_dependency "faraday_middleware", "~> 0.9.0"
+  spec.add_dependency "faraday", "~> 0.8"
+  spec.add_dependency "faraday_middleware", "~> 0.9"
 end


### PR DESCRIPTION
Hello, due too strict version dependencies it's hard to integrate into existing projects.