### PR TITLE
option to enable or disable request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ end
 
 Cardgate::Gateway.merchant = ''
 Cardgate::Gateway.api_key = ''
+Cardgate::Gateway.request_logger = true # or false if you want to disable request logging
 ```
 
 ## Contributing

--- a/lib/cardgate/gateway.rb
+++ b/lib/cardgate/gateway.rb
@@ -5,11 +5,7 @@ module Cardgate
   class Gateway
 
     class << self
-      attr_accessor :environment
-
-      attr_accessor :merchant
-
-      attr_accessor :api_key
+      attr_accessor :environment, :merchant, :api_key, :request_logger
     end
 
     def self.is_test_environment?
@@ -30,7 +26,7 @@ module Cardgate
       Faraday.new(url: self.request_url, ssl: { verify: !is_test_environment? } ) do |faraday|
         faraday.request  :json
         faraday.response :json
-        faraday.response :logger
+        faraday.response :logger if request_logger == true
         faraday.adapter  Faraday.default_adapter
         faraday.basic_auth self.merchant, self.api_key
       end

--- a/test/gateway_test.rb
+++ b/test/gateway_test.rb
@@ -38,6 +38,11 @@ module CardgateTestCases
       end
     end
 
+    def test_request_logger
+      Cardgate::Gateway.request_logger = true
+
+      assert_equal true, Cardgate::Gateway.request_logger
+    end
   end
 
 end


### PR DESCRIPTION
Option to enable or disable request logging. Useful for disabling request logging during tests. 